### PR TITLE
Add 1155 permissive minter

### DIFF
--- a/src/tokens/ERC1155/utility/minter/ERC1155PermissiveMinter.sol
+++ b/src/tokens/ERC1155/utility/minter/ERC1155PermissiveMinter.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.19;
+
+import {IERC1155ItemsFunctions} from "@0xsequence/contracts-library/tokens/ERC1155/presets/items/IERC1155Items.sol";
+
+/**
+ * An ERC-1155 contract that allows permissive minting.
+ */
+contract ERC1155PermissiveMinter {
+    /**
+     * Mint tokens.
+     * @param items The items contract.
+     * @param to Address to mint tokens to.
+     * @param tokenId Token ID to mint.
+     * @param amount Amount of tokens to mint.
+     * @param data Data to pass if receiver is contract.
+     */
+    function mint(address items, address to, uint256 tokenId, uint256 amount, bytes memory data) external {
+        IERC1155ItemsFunctions(items).mint(to, tokenId, amount, data);
+    }
+
+    /**
+     * Batch mint tokens.
+     * @param items The items contract.
+     * @param to Address to mint tokens to.
+     * @param tokenIds Token IDs to mint.
+     * @param amounts Amounts of tokens to mint.
+     * @param data Data to pass if receiver is contract.
+     */
+    function batchMint(
+        address items,
+        address to,
+        uint256[] memory tokenIds,
+        uint256[] memory amounts,
+        bytes memory data
+    ) external {
+        IERC1155ItemsFunctions(items).batchMint(to, tokenIds, amounts, data);
+    }
+}


### PR DESCRIPTION
Adds a copy of the 721 permissive minter for 1155s. This is great for demos and other situations where minting is entirely free and permission-less. 

1. Deploy 1155 Items
2. Deploy 1155 Permissive Minter
3. Give 1155 Permissive Minter the MINTER_ROLE (`0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6`) on the 1155 Items contract
4. Call Permissive Minter with any address to mint tokens