### PR TITLE
Add Payment Combiner

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "lib/solady"]
 	path = lib/solady
 	url = https://github.com/vectorized/solady
+[submodule "lib/openzeppelin-contracts-upgradeable"]
+	path = lib/openzeppelin-contracts-upgradeable
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable

--- a/remappings.txt
+++ b/remappings.txt
@@ -7,4 +7,5 @@ murky/=lib/murky/src/
 erc721a/=lib/chiru-labs/erc721a/
 erc721a-upgradeable/=lib/chiru-labs/erc721a-upgradeable/
 @openzeppelin/=lib/openzeppelin/
+@openzeppelin-upgradeable/=lib/openzeppelin-contracts-upgradeable/
 solady/=lib/solady/src/

--- a/src/payments/IPaymentCombiner.sol
+++ b/src/payments/IPaymentCombiner.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.19;
+
+interface IPaymentCombinerFunctions {
+    /**
+     * Get the address of the PaymentSplitter implementation.
+     * @return implementationAddr The address of the PaymentSplitter implementation.
+     */
+    function implementationAddress() external view returns (address implementationAddr);
+
+    /**
+     * Creates a PaymentSplitter proxy.
+     * @param payees The addresses of the payees
+     * @param shares The number of shares each payee has
+     * @return proxyAddr The address of the deployed proxy
+     */
+    function deploy(address[] calldata payees, uint256[] calldata shares) external returns (address proxyAddr);
+
+    /**
+     * Computes the address of a proxy instance.
+     * @param payees The addresses of the payees
+     * @param shares The number of shares each payee has
+     * @return proxyAddr The address of the proxy
+     */
+    function determineAddress(address[] calldata payees, uint256[] calldata shares) external returns (address proxyAddr);
+
+    /**
+     * Get the list of Payment Splitters this payee is associated with.
+     * @param payee The address of the payee
+     * @return splitterAddrs The list of payments splitters
+     */
+    function listPayeeSplitters(address payee) external view returns (address[] memory splitterAddrs);
+
+    /**
+     * Get the list of pending shares for a payee.
+     * @param payee The address of the payee
+     * @param tokenAddr The address of the ERC-20 token. If the token address is 0x0, then the native token is used.
+     * @return splitterAddrs The list of payments splitters with pending shares
+     * @return pendingShares The list of pending shares
+     * @dev The list includes zero balances. These should be removed before releasing shares.
+     */
+    function listReleasable(address payee, address tokenAddr)
+        external
+        view
+        returns (address[] memory splitterAddrs, uint256[] memory pendingShares);
+
+    /**
+     * Release the pending shares for a payee.
+     * @param payee The address of the payee
+     * @param tokenAddr The address of the ERC-20 token. If the token address is 0x0, then the native token is used.
+     * @param splitterAddrs The list of payments splitters to release shares from
+     * @dev Use the listReleasableSplitters function to get the list of splitters and pending shares
+     */
+    function release(address payable payee, address tokenAddr, address[] calldata splitterAddrs) external;
+}
+
+interface IPaymentCombinerSignals {
+    /**
+     * Event emitted when a new proxy contract is deployed.
+     * @param proxyAddr The address of the deployed proxy.
+     */
+    event PaymentSplitterDeployed(address proxyAddr);
+}
+
+interface IPaymentCombiner is IPaymentCombinerFunctions, IPaymentCombinerSignals {}

--- a/src/payments/IPaymentCombiner.sol
+++ b/src/payments/IPaymentCombiner.sol
@@ -27,11 +27,23 @@ interface IPaymentCombinerFunctions {
         returns (address proxyAddr);
 
     /**
+     * Get the amount of Payment Splitters this payee is associated with.
+     * @param payee The address of the payee
+     * @return count The amount of payments splitters
+     */
+    function countPayeeSplitters(address payee) external view returns (uint256 count);
+
+    /**
      * Get the list of Payment Splitters this payee is associated with.
      * @param payee The address of the payee
+     * @param offset The offset to start from
+     * @param limit The maximum amount of splitters to return
      * @return splitterAddrs The list of payments splitters
      */
-    function listPayeeSplitters(address payee) external view returns (address[] memory splitterAddrs);
+    function listPayeeSplitters(address payee, uint256 offset, uint256 limit)
+        external
+        view
+        returns (address[] memory splitterAddrs);
 
     /**
      * Get the list of pending shares for a payee.
@@ -63,6 +75,11 @@ interface IPaymentCombinerSignals {
      * @param proxyAddr The address of the deployed proxy.
      */
     event PaymentSplitterDeployed(address proxyAddr);
+
+    /**
+     * Thrown when the provided offset and limit are out of bounds.
+     */
+    error ParametersOutOfBounds(uint256 offset, uint256 limit, uint256 count);
 }
 
 interface IPaymentCombiner is IPaymentCombinerFunctions, IPaymentCombinerSignals {}

--- a/src/payments/IPaymentCombiner.sol
+++ b/src/payments/IPaymentCombiner.sol
@@ -22,7 +22,9 @@ interface IPaymentCombinerFunctions {
      * @param shares The number of shares each payee has
      * @return proxyAddr The address of the proxy
      */
-    function determineAddress(address[] calldata payees, uint256[] calldata shares) external returns (address proxyAddr);
+    function determineAddress(address[] calldata payees, uint256[] calldata shares)
+        external
+        returns (address proxyAddr);
 
     /**
      * Get the list of Payment Splitters this payee is associated with.
@@ -35,14 +37,14 @@ interface IPaymentCombinerFunctions {
      * Get the list of pending shares for a payee.
      * @param payee The address of the payee
      * @param tokenAddr The address of the ERC-20 token. If the token address is 0x0, then the native token is used.
-     * @return splitterAddrs The list of payments splitters with pending shares
+     * @param splitterAddrs The list of payments splitters to check
      * @return pendingShares The list of pending shares
      * @dev The list includes zero balances. These should be removed before releasing shares.
      */
-    function listReleasable(address payee, address tokenAddr)
+    function listReleasable(address payee, address tokenAddr, address[] memory splitterAddrs)
         external
         view
-        returns (address[] memory splitterAddrs, uint256[] memory pendingShares);
+        returns (uint256[] memory pendingShares);
 
     /**
      * Release the pending shares for a payee.

--- a/src/payments/IPaymentCombiner.sol
+++ b/src/payments/IPaymentCombiner.sol
@@ -37,7 +37,7 @@ interface IPaymentCombinerFunctions {
      * Get the list of pending shares for a payee.
      * @param payee The address of the payee
      * @param tokenAddr The address of the ERC-20 token. If the token address is 0x0, then the native token is used.
-     * @param splitterAddrs The list of payments splitters to check
+     * @param splitterAddrs The list of payments splitters to check. If empty then all splitters are used.
      * @return pendingShares The list of pending shares
      * @dev The list includes zero balances. These should be removed before releasing shares.
      */
@@ -50,8 +50,9 @@ interface IPaymentCombinerFunctions {
      * Release the pending shares for a payee.
      * @param payee The address of the payee
      * @param tokenAddr The address of the ERC-20 token. If the token address is 0x0, then the native token is used.
-     * @param splitterAddrs The list of payments splitters to release shares from
-     * @dev Use the listReleasableSplitters function to get the list of splitters and pending shares
+     * @param splitterAddrs The list of payments splitters to release shares from. If empty then all splitters are used.
+     * @dev Use the above functions to get the list of splitters and pending shares.
+     * @dev Calling splitters with no shares to release will fail.
      */
     function release(address payable payee, address tokenAddr, address[] calldata splitterAddrs) external;
 }

--- a/src/payments/PaymentCombiner.sol
+++ b/src/payments/PaymentCombiner.sol
@@ -72,12 +72,18 @@ contract PaymentCombiner is IPaymentCombiner, IERC165 {
         view
         returns (uint256[] memory pendingShares)
     {
-        uint256 len = splitterAddrs.length;
+        address[] memory splitters = splitterAddrs;
+        uint256 len = splitters.length;
+        if (len == 0) {
+            splitters = _payeeSplitters[payee];
+            len = splitters.length;
+        }
+
         uint256[] memory payeePendingShares = new uint256[](len);
 
         if (tokenAddr == address(0)) {
             for (uint256 i = 0; i < len;) {
-                payeePendingShares[i] = PaymentSplitter(payable(splitterAddrs[i])).releasable(payee);
+                payeePendingShares[i] = PaymentSplitter(payable(splitters[i])).releasable(payee);
                 unchecked {
                     i++;
                 }
@@ -85,7 +91,7 @@ contract PaymentCombiner is IPaymentCombiner, IERC165 {
         } else {
             IERC20Upgradeable token = IERC20Upgradeable(tokenAddr);
             for (uint256 i = 0; i < len;) {
-                payeePendingShares[i] = PaymentSplitter(payable(splitterAddrs[i])).releasable(token, payee);
+                payeePendingShares[i] = PaymentSplitter(payable(splitters[i])).releasable(token, payee);
                 unchecked {
                     i++;
                 }
@@ -97,10 +103,16 @@ contract PaymentCombiner is IPaymentCombiner, IERC165 {
 
     /// @inheritdoc IPaymentCombinerFunctions
     function release(address payable payee, address tokenAddr, address[] calldata splitterAddrs) external {
-        uint256 len = splitterAddrs.length;
+        address[] memory splitters = splitterAddrs;
+        uint256 len = splitters.length;
+        if (len == 0) {
+            splitters = _payeeSplitters[payee];
+            len = splitters.length;
+        }
+
         if (tokenAddr == address(0)) {
             for (uint256 i = 0; i < len;) {
-                PaymentSplitter(payable(splitterAddrs[i])).release(payee);
+                PaymentSplitter(payable(splitters[i])).release(payee);
                 unchecked {
                     i++;
                 }
@@ -108,7 +120,7 @@ contract PaymentCombiner is IPaymentCombiner, IERC165 {
         } else {
             IERC20Upgradeable token = IERC20Upgradeable(tokenAddr);
             for (uint256 i = 0; i < len;) {
-                PaymentSplitter(payable(splitterAddrs[i])).release(token, payee);
+                PaymentSplitter(payable(splitters[i])).release(token, payee);
                 unchecked {
                     i++;
                 }

--- a/src/payments/PaymentCombiner.sol
+++ b/src/payments/PaymentCombiner.sol
@@ -62,8 +62,26 @@ contract PaymentCombiner is IPaymentCombiner, IERC165 {
     }
 
     /// @inheritdoc IPaymentCombinerFunctions
-    function listPayeeSplitters(address payee) external view returns (address[] memory splitterAddrs) {
-        return _payeeSplitters[payee];
+    function countPayeeSplitters(address payee) external view returns (uint256 count) {
+        return _payeeSplitters[payee].length;
+    }
+
+    /// @inheritdoc IPaymentCombinerFunctions
+    function listPayeeSplitters(address payee, uint256 offset, uint256 limit)
+        external
+        view
+        returns (address[] memory splitterAddrs)
+    {
+        address[] memory payeeSplitters = _payeeSplitters[payee];
+        uint256 len = payeeSplitters.length;
+        if (offset + limit > len) {
+            revert ParametersOutOfBounds(offset, limit, len);
+        }
+        splitterAddrs = new address[](limit);
+        for (uint256 i = 0; i < limit; i++) {
+            splitterAddrs[i] = _payeeSplitters[payee][i + offset];
+        }
+        return splitterAddrs;
     }
 
     /// @inheritdoc IPaymentCombinerFunctions

--- a/src/payments/PaymentCombiner.sol
+++ b/src/payments/PaymentCombiner.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.19;
+
+import {PaymentSplitter, IERC20Upgradeable} from "@0xsequence/contracts-library/payments/PaymentSplitter.sol";
+import {
+    IPaymentCombiner, IPaymentCombinerFunctions
+} from "@0xsequence/contracts-library/payments/IPaymentCombiner.sol";
+import {IERC165} from "@0xsequence/erc-1155/contracts/interfaces/IERC165.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+
+/**
+ * Deployer of Payment Splitter proxies.
+ * @dev Unlike other factories in this library, payment splitters are unowned and not upgradeable.
+ */
+contract PaymentCombiner is IPaymentCombiner, IERC165 {
+    using Clones for address;
+
+    address private immutable _IMPLEMENTATION;
+
+    mapping(address => address[]) private _payeeSplitters;
+
+    /**
+     * Creates a Payment Splitter Factory.
+     */
+    constructor() {
+        _IMPLEMENTATION = address(new PaymentSplitter());
+    }
+
+    /// @inheritdoc IPaymentCombinerFunctions
+    function implementationAddress() external view returns (address) {
+        return _IMPLEMENTATION;
+    }
+
+    /// @inheritdoc IPaymentCombinerFunctions
+    function deploy(address[] calldata payees, uint256[] calldata shares) external returns (address proxyAddr) {
+        bytes32 salt = _determineSalt(payees, shares);
+        proxyAddr = _IMPLEMENTATION.cloneDeterministic(salt);
+        PaymentSplitter(payable(proxyAddr)).initialize(payees, shares);
+        emit PaymentSplitterDeployed(proxyAddr);
+
+        // Add the payees to the list of payee splitters
+        for (uint256 i = 0; i < payees.length; i++) {
+            _payeeSplitters[payees[i]].push(proxyAddr);
+        }
+
+        return proxyAddr;
+    }
+
+    /// @inheritdoc IPaymentCombinerFunctions
+    function determineAddress(address[] calldata payees, uint256[] calldata shares)
+        external
+        view
+        returns (address proxyAddr)
+    {
+        bytes32 salt = _determineSalt(payees, shares);
+        return _IMPLEMENTATION.predictDeterministicAddress(salt);
+    }
+
+    /// @dev Computes the deployment salt for a Payment Splitter.
+    function _determineSalt(address[] calldata payees, uint256[] calldata shares) internal pure returns (bytes32) {
+        return keccak256(abi.encode(payees, shares));
+    }
+
+    /// @inheritdoc IPaymentCombinerFunctions
+    function listPayeeSplitters(address payee) external view returns (address[] memory splitterAddrs) {
+        return _payeeSplitters[payee];
+    }
+
+    /// @inheritdoc IPaymentCombinerFunctions
+    function listReleasable(address payee, address tokenAddr)
+        external
+        view
+        returns (address[] memory splitterAddrs, uint256[] memory pendingShares)
+    {
+        address[] memory payeeSplitters = _payeeSplitters[payee];
+        uint256 len = payeeSplitters.length;
+        uint256[] memory payeePendingShares = new uint256[](len);
+
+        if (tokenAddr == address(0)) {
+            for (uint256 i = 0; i < len;) {
+                payeePendingShares[i] = PaymentSplitter(payable(payeeSplitters[i])).releasable(payee);
+                unchecked {
+                    i++;
+                }
+            }
+        } else {
+            for (uint256 i = 0; i < len;) {
+                payeePendingShares[i] =
+                    PaymentSplitter(payable(payeeSplitters[i])).releasable(IERC20Upgradeable(tokenAddr), payee);
+                unchecked {
+                    i++;
+                }
+            }
+        }
+
+        return (payeeSplitters, payeePendingShares);
+    }
+
+    /// @inheritdoc IPaymentCombinerFunctions
+    function release(address payable payee, address tokenAddr, address[] calldata splitterAddrs) external {
+        uint256 len = splitterAddrs.length;
+        if (tokenAddr == address(0)) {
+            for (uint256 i = 0; i < len;) {
+                PaymentSplitter(payable(splitterAddrs[i])).release(payee);
+                unchecked {
+                    i++;
+                }
+            }
+        } else {
+            for (uint256 i = 0; i < len;) {
+                PaymentSplitter(payable(splitterAddrs[i])).release(IERC20Upgradeable(tokenAddr), payee);
+                unchecked {
+                    i++;
+                }
+            }
+        }
+    }
+
+    /// @inheritdoc IERC165
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return type(IPaymentCombiner).interfaceId == interfaceId
+            || type(IPaymentCombinerFunctions).interfaceId == interfaceId || type(IERC165).interfaceId == interfaceId;
+    }
+}

--- a/src/payments/PaymentCombiner.sol
+++ b/src/payments/PaymentCombiner.sol
@@ -67,33 +67,32 @@ contract PaymentCombiner is IPaymentCombiner, IERC165 {
     }
 
     /// @inheritdoc IPaymentCombinerFunctions
-    function listReleasable(address payee, address tokenAddr)
+    function listReleasable(address payee, address tokenAddr, address[] calldata splitterAddrs)
         external
         view
-        returns (address[] memory splitterAddrs, uint256[] memory pendingShares)
+        returns (uint256[] memory pendingShares)
     {
-        address[] memory payeeSplitters = _payeeSplitters[payee];
-        uint256 len = payeeSplitters.length;
+        uint256 len = splitterAddrs.length;
         uint256[] memory payeePendingShares = new uint256[](len);
 
         if (tokenAddr == address(0)) {
             for (uint256 i = 0; i < len;) {
-                payeePendingShares[i] = PaymentSplitter(payable(payeeSplitters[i])).releasable(payee);
+                payeePendingShares[i] = PaymentSplitter(payable(splitterAddrs[i])).releasable(payee);
                 unchecked {
                     i++;
                 }
             }
         } else {
+            IERC20Upgradeable token = IERC20Upgradeable(tokenAddr);
             for (uint256 i = 0; i < len;) {
-                payeePendingShares[i] =
-                    PaymentSplitter(payable(payeeSplitters[i])).releasable(IERC20Upgradeable(tokenAddr), payee);
+                payeePendingShares[i] = PaymentSplitter(payable(splitterAddrs[i])).releasable(token, payee);
                 unchecked {
                     i++;
                 }
             }
         }
 
-        return (payeeSplitters, payeePendingShares);
+        return payeePendingShares;
     }
 
     /// @inheritdoc IPaymentCombinerFunctions
@@ -107,8 +106,9 @@ contract PaymentCombiner is IPaymentCombiner, IERC165 {
                 }
             }
         } else {
+            IERC20Upgradeable token = IERC20Upgradeable(tokenAddr);
             for (uint256 i = 0; i < len;) {
-                PaymentSplitter(payable(splitterAddrs[i])).release(IERC20Upgradeable(tokenAddr), payee);
+                PaymentSplitter(payable(splitterAddrs[i])).release(token, payee);
                 unchecked {
                     i++;
                 }

--- a/src/payments/PaymentSplitter.sol
+++ b/src/payments/PaymentSplitter.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.19;
+
+import {
+    PaymentSplitterUpgradeable,
+    IERC20Upgradeable
+} from "@openzeppelin-upgradeable/contracts/finance/PaymentSplitterUpgradeable.sol";
+
+contract PaymentSplitter is PaymentSplitterUpgradeable {
+    /**
+     * Initialize the PaymentSplitter contract.
+     * @param payees The addresses of the payees
+     * @param shares The number of shares each payee has
+     * @dev This function should be called only once immediately after the contract is deployed.
+     */
+    function initialize(address[] memory payees, uint256[] memory shares) public initializer {
+        __PaymentSplitter_init(payees, shares);
+    }
+}

--- a/test/TestHelper.sol
+++ b/test/TestHelper.sol
@@ -46,6 +46,14 @@ abstract contract TestHelper is Test, Merkle {
         }
     }
 
+    function assumeNoDuplicates(address[] memory values) internal pure {
+        for (uint256 i = 0; i < values.length; i++) {
+            for (uint256 j = i + 1; j < values.length; j++) {
+                vm.assume(values[i] != values[j]);
+            }
+        }
+    }
+
     function getMerkleParts(address[] memory allowlist, uint256 salt, uint256 leafIndex) internal pure returns (bytes32 root, bytes32[] memory proof) {
         bytes32[] memory leaves = new bytes32[](allowlist.length);
         for (uint256 i = 0; i < allowlist.length; i++) {

--- a/test/payments/PaymentCombiner.t.sol
+++ b/test/payments/PaymentCombiner.t.sol
@@ -103,12 +103,10 @@ contract PaymentCombinerTest is TestHelper, IPaymentCombinerSignals {
             payable(splitterAddrs[i]).transfer(amount);
         }
 
-        (address[] memory splitterReleasable, uint256[] memory pendingShares) =
-            combiner.listReleasable(payable(targetPayee), address(0));
+        uint256[] memory pendingShares = combiner.listReleasable(payable(targetPayee), address(0), splitterAddrs);
 
-        for (uint256 i = 0; i < splitterReleasable.length; i++) {
-            assertEq(splitterReleasable[i], splitterAddrs[i]);
-            PaymentSplitter splitter = PaymentSplitter(payable(splitterReleasable[i]));
+        for (uint256 i = 0; i < splitterAddrs.length; i++) {
+            PaymentSplitter splitter = PaymentSplitter(payable(splitterAddrs[i]));
             assertEq(splitter.releasable(targetPayee), pendingShares[i]);
         }
     }
@@ -130,12 +128,10 @@ contract PaymentCombinerTest is TestHelper, IPaymentCombinerSignals {
             erc20.transfer(splitterAddrs[i], amount);
         }
 
-        (address[] memory splitterReleasable, uint256[] memory pendingShares) =
-            combiner.listReleasable(payable(targetPayee), address(erc20));
+        uint256[] memory pendingShares = combiner.listReleasable(payable(targetPayee), address(erc20), splitterAddrs);
 
-        for (uint256 i = 0; i < splitterReleasable.length; i++) {
-            assertEq(splitterReleasable[i], splitterAddrs[i]);
-            PaymentSplitter splitter = PaymentSplitter(payable(splitterReleasable[i]));
+        for (uint256 i = 0; i < splitterAddrs.length; i++) {
+            PaymentSplitter splitter = PaymentSplitter(payable(splitterAddrs[i]));
             assertEq(splitter.releasable(IERC20Upgradeable(address(erc20)), targetPayee), pendingShares[i]);
         }
     }

--- a/test/payments/PaymentCombiner.t.sol
+++ b/test/payments/PaymentCombiner.t.sol
@@ -65,6 +65,14 @@ contract PaymentCombinerTest is TestHelper, IPaymentCombinerSignals {
         assertEq(expectedAddr, actualAddr);
     }
 
+    function testRepeatedDeploysFail(address[] memory payees, uint256[] memory shares) public {
+        (payees, shares) = _validArrays(payees, shares);
+        combiner.deploy(payees, shares);
+
+        vm.expectRevert();
+        combiner.deploy(payees, shares);
+    }
+
     function testListPayeeSplitters(
         address[] memory payees1,
         address[] memory payees2,

--- a/test/payments/PaymentCombiner.t.sol
+++ b/test/payments/PaymentCombiner.t.sol
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.19;
+
+import {TestHelper} from "../TestHelper.sol";
+import {ERC20Mock} from "../_mocks/ERC20Mock.sol";
+
+import {PaymentCombiner, PaymentSplitter, IERC20Upgradeable} from "src/payments/PaymentCombiner.sol";
+import {IPaymentCombiner, IPaymentCombinerSignals, IPaymentCombinerFunctions} from "src/payments/IPaymentCombiner.sol";
+import {IERC165} from "@0xsequence/erc-1155/contracts/interfaces/IERC165.sol";
+
+// Note we are not testing the OZ PaymentSplitter contract implementation, only the PaymentCombiner contract
+
+contract PaymentCombinerTest is TestHelper, IPaymentCombinerSignals {
+    PaymentCombiner public combiner;
+    ERC20Mock public erc20;
+
+    function setUp() public {
+        combiner = new PaymentCombiner();
+        erc20 = new ERC20Mock(address(this));
+    }
+
+    function testSupportsInterface() public view {
+        assertTrue(combiner.supportsInterface(type(IERC165).interfaceId));
+        assertTrue(combiner.supportsInterface(type(IPaymentCombiner).interfaceId));
+        assertTrue(combiner.supportsInterface(type(IPaymentCombinerFunctions).interfaceId));
+    }
+
+    function _validArrays(address[] memory payees, uint256[] memory shares)
+        internal
+        view
+        returns (address[] memory, uint256[] memory)
+    {
+        uint256 payeeLength = payees.length;
+        vm.assume(payeeLength > 0);
+        uint256 sharesLength = shares.length;
+        vm.assume(sharesLength > 0);
+
+        uint256 maxLen = 5;
+        maxLen = payeeLength < maxLen ? payeeLength : maxLen;
+        maxLen = sharesLength < maxLen ? sharesLength : maxLen;
+        assembly {
+            mstore(payees, maxLen)
+            mstore(shares, maxLen)
+        }
+
+        // Make sure addr is safe
+        for (uint256 i = 0; i < maxLen; i++) {
+            assumeSafeAddress(payees[i]);
+        }
+        assumeNoDuplicates(payees);
+
+        // Bind shares to prevent overflow
+        for (uint256 i = 0; i < maxLen; i++) {
+            shares[i] = _bound(shares[i], 1, 100);
+        }
+
+        return (payees, shares);
+    }
+
+    function testDetermineAddress(address[] memory payees, uint256[] memory shares) public {
+        (payees, shares) = _validArrays(payees, shares);
+
+        address expectedAddr = combiner.determineAddress(payees, shares);
+        address actualAddr = combiner.deploy(payees, shares);
+        assertEq(expectedAddr, actualAddr);
+    }
+
+    function testListPayeeSplitters(
+        address[] memory payees1,
+        address[] memory payees2,
+        uint256[] memory shares1,
+        uint256[] memory shares2
+    ) public returns (address targetPayee, address[] memory splitterAddrs) {
+        vm.assume(payees1.length > 0);
+        vm.assume(payees2.length > 0);
+        targetPayee = payees1[0];
+        payees2[0] = targetPayee;
+        (payees1, shares1) = _validArrays(payees1, shares1);
+        (payees2, shares2) = _validArrays(payees2, shares2);
+
+        address splitter1 = combiner.deploy(payees1, shares1);
+        address splitter2 = combiner.deploy(payees2, shares2);
+        splitterAddrs = combiner.listPayeeSplitters(targetPayee);
+        assertEq(splitterAddrs.length, 2);
+        assertEq(splitterAddrs[0], splitter1);
+        assertEq(splitterAddrs[1], splitter2);
+    }
+
+    function testListReleasableNative(
+        uint256 amount,
+        address[] memory payees1,
+        address[] memory payees2,
+        uint256[] memory shares1,
+        uint256[] memory shares2
+    ) public returns (address targetPayee, address[] memory splitterAddrs) {
+        (targetPayee, splitterAddrs) = testListPayeeSplitters(payees1, payees2, shares1, shares2);
+
+        amount = _bound(amount, 0.1 ether, 1 ether);
+        vm.deal(address(this), amount * splitterAddrs.length);
+
+        for (uint256 i = 0; i < splitterAddrs.length; i++) {
+            // Fund splitters
+            payable(splitterAddrs[i]).transfer(amount);
+        }
+
+        (address[] memory splitterReleasable, uint256[] memory pendingShares) =
+            combiner.listReleasable(payable(targetPayee), address(0));
+
+        for (uint256 i = 0; i < splitterReleasable.length; i++) {
+            assertEq(splitterReleasable[i], splitterAddrs[i]);
+            PaymentSplitter splitter = PaymentSplitter(payable(splitterReleasable[i]));
+            assertEq(splitter.releasable(targetPayee), pendingShares[i]);
+        }
+    }
+
+    function testListReleasableERC20(
+        uint256 amount,
+        address[] memory payees1,
+        address[] memory payees2,
+        uint256[] memory shares1,
+        uint256[] memory shares2
+    ) public returns (address targetPayee, address[] memory splitterAddrs) {
+        (targetPayee, splitterAddrs) = testListPayeeSplitters(payees1, payees2, shares1, shares2);
+
+        amount = _bound(amount, 0.1 ether, 1 ether);
+        erc20.mint(address(this), 0, amount * splitterAddrs.length);
+
+        for (uint256 i = 0; i < splitterAddrs.length; i++) {
+            // Fund splitters
+            erc20.transfer(splitterAddrs[i], amount);
+        }
+
+        (address[] memory splitterReleasable, uint256[] memory pendingShares) =
+            combiner.listReleasable(payable(targetPayee), address(erc20));
+
+        for (uint256 i = 0; i < splitterReleasable.length; i++) {
+            assertEq(splitterReleasable[i], splitterAddrs[i]);
+            PaymentSplitter splitter = PaymentSplitter(payable(splitterReleasable[i]));
+            assertEq(splitter.releasable(IERC20Upgradeable(address(erc20)), targetPayee), pendingShares[i]);
+        }
+    }
+
+    function testListReleaseNative(
+        uint256 amount,
+        address[] memory payees1,
+        address[] memory payees2,
+        uint256[] memory shares1,
+        uint256[] memory shares2
+    ) public {
+        (address targetPayee, address[] memory splitterAddrs) =
+            testListReleasableNative(amount, payees1, payees2, shares1, shares2);
+
+        combiner.release(payable(targetPayee), address(0), splitterAddrs);
+
+        for (uint256 i = 0; i < splitterAddrs.length; i++) {
+            PaymentSplitter splitter = PaymentSplitter(payable(splitterAddrs[i]));
+            assertGt(splitter.released(targetPayee), 0);
+            assertEq(splitter.released(IERC20Upgradeable(address(erc20)), targetPayee), 0);
+        }
+    }
+
+    function testListReleaseERC20(
+        uint256 amount,
+        address[] memory payees1,
+        address[] memory payees2,
+        uint256[] memory shares1,
+        uint256[] memory shares2
+    ) public {
+        (address targetPayee, address[] memory splitterAddrs) =
+            testListReleasableERC20(amount, payees1, payees2, shares1, shares2);
+
+        combiner.release(payable(targetPayee), address(erc20), splitterAddrs);
+
+        for (uint256 i = 0; i < splitterAddrs.length; i++) {
+            PaymentSplitter splitter = PaymentSplitter(payable(splitterAddrs[i]));
+            assertGt(splitter.released(IERC20Upgradeable(address(erc20)), targetPayee), 0);
+            assertEq(splitter.released(targetPayee), 0);
+        }
+    }
+}


### PR DESCRIPTION
`PaymentCombiner` is a factory for deploying OZ's `PaymentSplitter`. This combiner also includes helper functions for batch calling the deployed splitters. 