### PR TITLE
ERC1155 sale contract globalSaleDetails and tokenSaleDetails as view in interface

### DIFF
--- a/src/tokens/ERC1155/utility/sale/IERC1155Sale.sol
+++ b/src/tokens/ERC1155/utility/sale/IERC1155Sale.sol
@@ -17,7 +17,7 @@ interface IERC1155SaleFunctions {
      * @notice Global sales details apply to all tokens.
      * @notice Global sales details are overriden when token sale is active.
      */
-    function globalSaleDetails() external returns (SaleDetails memory);
+    function globalSaleDetails() external view returns (SaleDetails memory);
 
     /**
      * Get token sale details.
@@ -25,7 +25,7 @@ interface IERC1155SaleFunctions {
      * @return Sale details.
      * @notice Token sale details override global sale details.
      */
-    function tokenSaleDetails(uint256 tokenId) external returns (SaleDetails memory);
+    function tokenSaleDetails(uint256 tokenId) external view returns (SaleDetails memory);
 
     /**
      * Get payment token.


### PR DESCRIPTION
I got issue, when these 2 methods `globalSaleDetails()` and `tokenSaleDetails()` wasn't generated in clients as read only methods.

I checked the code for `ERC721` and noticed one difference between these methods and `saleDetails()` for `ERC721` so i made this little change and it generated me expected client with read only methods.

If the approach is wrong, then close this PR please.

https://github.com/0xsequence/contracts-library/blob/master/src/tokens/ERC721/utility/sale/IERC721Sale.sol#L55