### PR TITLE
Add ERC1155 batch support

### DIFF
--- a/src/tokens/ERC1155/presets/lootbox/ERC1155Lootbox.sol
+++ b/src/tokens/ERC1155/presets/lootbox/ERC1155Lootbox.sol
@@ -69,7 +69,7 @@ contract ERC1155Lootbox is ERC1155Items, IERC1155Lootbox {
         _availableIndices[randomIndex] = _getIndexOrDefault(remainingSupply);
 
         for (uint256 i = 0; i < boxContent.tokenAddresses.length; i++) {
-            IERC1155ItemsFunctions(boxContent.tokenAddresses[i]).mint(
+            IERC1155ItemsFunctions(boxContent.tokenAddresses[i]).batchMint(
                 user, boxContent.tokenIds[i], boxContent.amounts[i], ""
             );
         }

--- a/src/tokens/ERC1155/presets/lootbox/IERC1155Lootbox.sol
+++ b/src/tokens/ERC1155/presets/lootbox/IERC1155Lootbox.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.19;
 interface IERC1155LootboxFunctions {
     struct BoxContent {
         address[] tokenAddresses;
-        uint256[] tokenIds;
-        uint256[] amounts;
+        uint256[][] tokenIds;
+        uint256[][] amounts;
     }
 
     /**


### PR DESCRIPTION
Adds batch minting to lootboxes. 

The updated structure adds gas overhead to every call. This is optimised away with a batch call. 

I think this approach makes sense for project looking to have multiple different items per box as they will likely be using the same ERC1155 contract. But I wonder if single item boxes will be a more common use case and so it becomes more gas efficient to leave this out. 