### PR TITLE
Emit an event after pack reveal

### DIFF
--- a/src/tokens/ERC1155/presets/pack/ERC1155Pack.sol
+++ b/src/tokens/ERC1155/presets/pack/ERC1155Pack.sol
@@ -78,6 +78,8 @@ contract ERC1155Pack is ERC1155Items, IERC1155Pack {
                 user, packContent.tokenIds[i], packContent.amounts[i], ""
             );
         }
+
+        emit Reveal(user, packContent);
     }
 
     /// @inheritdoc IERC1155Pack

--- a/src/tokens/ERC1155/presets/pack/ERC1155Pack.sol
+++ b/src/tokens/ERC1155/presets/pack/ERC1155Pack.sol
@@ -79,7 +79,7 @@ contract ERC1155Pack is ERC1155Items, IERC1155Pack {
             );
         }
 
-        emit Reveal(user, packContent);
+        emit Reveal(user);
     }
 
     /// @inheritdoc IERC1155Pack

--- a/src/tokens/ERC1155/presets/pack/IERC1155Pack.sol
+++ b/src/tokens/ERC1155/presets/pack/IERC1155Pack.sol
@@ -42,7 +42,7 @@ interface IERC1155Pack {
     event Commit(address indexed user, uint256 blockNumber);
 
     /// @notice Emitted when a reveal is successful
-    event Reveal(address user, PackContent packContent);
+    event Reveal(address indexed user);
 
     /**
      * Initialize the contract.

--- a/src/tokens/ERC1155/presets/pack/IERC1155Pack.sol
+++ b/src/tokens/ERC1155/presets/pack/IERC1155Pack.sol
@@ -38,8 +38,11 @@ interface IERC1155Pack {
      */
     error AllPacksOpened();
 
-    /// @notice Emits when a user make a commitment
+    /// @notice Emitted when a user make a commitment
     event Commit(address indexed user, uint256 blockNumber);
+
+    /// @notice Emitted when a reveal is successful
+    event Reveal(address user, PackContent packContent);
 
     /**
      * Initialize the contract.

--- a/src/tokens/ERC1155/presets/pack/IERC1155Pack.sol
+++ b/src/tokens/ERC1155/presets/pack/IERC1155Pack.sol
@@ -42,7 +42,7 @@ interface IERC1155Pack {
     event Commit(address indexed user, uint256 blockNumber);
 
     /// @notice Emitted when a reveal is successful
-    event Reveal(address indexed user);
+    event Reveal(address user);
 
     /**
      * Initialize the contract.


### PR DESCRIPTION
We need to emit an event after the reveal is successful so the client can detect it and display the pack's content.