### PR TITLE
Replace ERC721A with Solady ERC721

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/openzeppelin/openzeppelin-contracts
-[submodule "lib/erc721a"]
-	path = lib/erc721a
-	url = https://github.com/chiru-labs/erc721a
 [submodule "lib/openzeppelin-contracts-upgradeable"]
 	path = lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/openzeppelin/openzeppelin-contracts-upgradeable

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,6 @@
   "solidity.compileUsingRemoteVersion": "v0.8.27",
   "solidity.remappings": [
     "erc2470-libs/=lib/erc2470-libs/",
-    "erc721a/=lib/erc721a/contracts/",
     "openzeppelin-contracts/=lib/openzeppelin-contracts/",
     "openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/",
     "forge-std/=lib/forge-std/src/",

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ yarn deploy --rpc-url $RPC_URL --broadcast
 
 ## Dependencies
 
-The contracts in this repository are built with Solidity ^0.8.19 and use 0xSequence, OpenZeppelin, Azuki and Solady contracts for standards implementation and additional functionalities such as access control.
+The contracts in this repository are built with Solidity ^0.8.19 and use 0xSequence, OpenZeppelin and Solady contracts for standards implementation and additional functionalities such as access control.
 
 ## Audits
 

--- a/src/tokens/ERC721/README.md
+++ b/src/tokens/ERC721/README.md
@@ -4,7 +4,7 @@ This subsection contains contracts related to the [ERC721 token standard](https:
 
 ## ERC721BaseToken
 
-This contract is a base implementation of the ERC-721 token standard. It leverages the [Azuki ERC-721A implementation](https://www.erc721a.org/) for gas efficiency. It includes role based access control features from the [OpenZeppelin AccessControlEnumberable](https://docs.openzeppelin.com/contracts/4.x/access-control) contract, to provide control over added features. Please refer to OpenZeppelin documentation for more information on `AccessControlEnumberable`.
+This contract is a base implementation of the ERC-721 token standard. It leverages the [Solady ERC-721 implementation](https://vectorized.github.io/solady/) for gas efficiency. It includes role based access control features from the [OpenZeppelin AccessControlEnumberable](https://docs.openzeppelin.com/contracts/4.x/access-control) contract, to provide control over added features. Please refer to OpenZeppelin documentation for more information on `AccessControlEnumberable`.
 
 The contract supports the [ERC2981 token royalty standard](https://eips.ethereum.org/EIPS/eip-2981) via the ERC2981Controlled contract. Please refer to the ERC2981Controlled documentation for more information on token royalty.
 
@@ -42,7 +42,7 @@ This section of this repo utilitizes a factory pattern that deploys proxies cont
 
 ## Dependencies
 
-This repo relies on the `ERC721A`, `IERC721A`, `ERC721AQueryable`, and `IERC721AQueryable` contracts from Azuki for core ERC-721 functionality, `AccessControlEnumberable` from OpenZeppelin for role base permissions and the ERC2981Controlled contract for handling of royalties.
+This repo relies on the `ERC721` contract from Solady for core ERC-721 functionality, `AccessControlEnumberable` from OpenZeppelin for role base permissions and the ERC2981Controlled contract for handling of royalties.
 
 ## Access Controls
 

--- a/src/tokens/ERC721/presets/items/ERC721Items.sol
+++ b/src/tokens/ERC721/presets/items/ERC721Items.sol
@@ -14,6 +14,9 @@ contract ERC721Items is ERC721BaseToken, IERC721Items {
     address private immutable _initializer;
     bool private _initialized;
 
+    uint256 private _nextSequentialId;
+    uint256 private _totalSupply;
+
     /**
      * Deploy contract.
      */
@@ -63,18 +66,35 @@ contract ERC721Items is ERC721BaseToken, IERC721Items {
     // Minting
     //
 
-    /**
-     * Mint tokens.
-     * @param to Address to mint tokens to.
-     * @param amount Amount of tokens to mint.
-     */
-    function mint(address to, uint256 amount) external onlyRole(MINTER_ROLE) {
-        _mint(to, amount);
+    /// @inheritdoc IERC721ItemsFunctions
+    function mint(address to, uint256 tokenId) external onlyRole(MINTER_ROLE) {
+        _mint(to, tokenId);
+        _totalSupply++;
+        while (_exists(_nextSequentialId)) {
+            _nextSequentialId++;
+        }
+    }
+
+    /// @inheritdoc IERC721ItemsFunctions
+    function mintSequential(address to, uint256 amount) external onlyRole(MINTER_ROLE) {
+        for (uint256 i = 0; i < amount; i++) {
+            while (_exists(_nextSequentialId)) {
+                _nextSequentialId++;
+            }
+            _mint(to, _nextSequentialId);
+            _nextSequentialId++;
+        }
+        _totalSupply += amount;
     }
 
     //
     // Views
     //
+
+    /// @inheritdoc IERC721ItemsFunctions
+    function totalSupply() external view returns (uint256) {
+        return _totalSupply;
+    }
 
     /**
      * Check interface support.

--- a/src/tokens/ERC721/presets/items/IERC721Items.sol
+++ b/src/tokens/ERC721/presets/items/IERC721Items.sol
@@ -6,9 +6,22 @@ interface IERC721ItemsFunctions {
     /**
      * Mint tokens.
      * @param to Address to mint tokens to.
+     * @param tokenId Token id to mint.
+     */
+    function mint(address to, uint256 tokenId) external;
+
+    /**
+     * Mint a sequential token.
+     * @param to Address to mint token to.
      * @param amount Amount of tokens to mint.
      */
-    function mint(address to, uint256 amount) external;
+    function mintSequential(address to, uint256 amount) external;
+
+    /**
+     * Get the total supply of tokens.
+     * @return totalSupply The total supply of tokens.
+     */
+    function totalSupply() external view returns (uint256 totalSupply);
 
 }
 

--- a/src/tokens/ERC721/presets/soulbound/ERC721Soulbound.sol
+++ b/src/tokens/ERC721/presets/soulbound/ERC721Soulbound.sol
@@ -54,17 +54,12 @@ contract ERC721Soulbound is ERC721Items, IERC721Soulbound {
         return _transferLocked;
     }
 
-    function _beforeTokenTransfers(
-        address from,
-        address to,
-        uint256 startTokenId,
-        uint256 quantity
-    ) internal virtual override {
+    function _beforeTokenTransfer(address from, address to, uint256 tokenId) internal virtual override {
         // Mint transactions allowed
         if (_transferLocked && from != address(0)) {
             revert TransfersLocked();
         }
-        super._beforeTokenTransfers(from, to, startTokenId, quantity);
+        super._beforeTokenTransfer(from, to, tokenId);
     }
 
     function supportsInterface(

--- a/src/tokens/ERC721/utility/sale/ERC721Sale.sol
+++ b/src/tokens/ERC721/utility/sale/ERC721Sale.sol
@@ -7,8 +7,6 @@ import { AccessControlEnumerable, IERC20, SafeERC20, WithdrawControlled } from "
 import { IERC721ItemsFunctions } from "../../presets/items/IERC721Items.sol";
 import { IERC721Sale, IERC721SaleFunctions } from "./IERC721Sale.sol";
 
-import { IERC721A } from "erc721a/extensions/ERC721AQueryable.sol";
-
 /**
  * An ERC-721 token contract with primary sale mechanisms.
  */
@@ -127,13 +125,13 @@ contract ERC721Sale is IERC721Sale, WithdrawControlled, MerkleProofSingleUse, Si
     ) public payable {
         _payForActiveMint(amount, paymentToken, maxTotal, proof);
 
-        uint256 currentSupply = IERC721A(_items).totalSupply();
+        uint256 currentSupply = IERC721ItemsFunctions(_items).totalSupply();
         uint256 supplyCap = _saleDetails.supplyCap;
         if (supplyCap > 0 && currentSupply + amount > supplyCap) {
             revert InsufficientSupply(currentSupply, amount, supplyCap);
         }
 
-        IERC721ItemsFunctions(_items).mint(to, amount);
+        IERC721ItemsFunctions(_items).mintSequential(to, amount);
         emit ItemsMinted(to, amount);
     }
 

--- a/test/_mocks/ERC721Mock.sol
+++ b/test/_mocks/ERC721Mock.sol
@@ -11,17 +11,12 @@ contract ERC721Mock is ERC721BaseToken, IGenericToken {
         _initialize(owner, "", "", tokenBaseURI, "", address(0), bytes32(0));
     }
 
-    function _sequentialUpTo() internal pure override returns (uint256) {
-        // Force non sequential minting
-        return 0;
-    }
-
     function mint(address to, uint256 tokenId, uint256) external override {
-        _mintSpot(to, tokenId);
+        _mint(to, tokenId);
     }
 
-    function approve(address, address operator, uint256 tokenId, uint256) external override {
-        _approve(operator, tokenId, false);
+    function approve(address owner, address operator, uint256 tokenId, uint256) external override {
+        _approve(owner, operator, tokenId);
     }
 
     function balanceOf(address owner, uint256 tokenId) external view override returns (uint256) {

--- a/test/tokens/wrappers/clawback/ClawbackTestBase.sol
+++ b/test/tokens/wrappers/clawback/ClawbackTestBase.sol
@@ -77,7 +77,7 @@ contract ClawbackTestBase is Test, IERC1155Receiver, IERC721Receiver {
     ) internal returns (WrapSetupResult memory result) {
         vm.assume(templateAdmin != address(0));
 
-        // Unwrap timestamp is uint64 as per ERC721A implmentation used by ERC721Mock
+        // Unwrap timestamp is uint64 as per ERC721 implementation used by ERC721Mock
         result.duration = uint56(bound(duration, 1, type(uint64).max - block.timestamp));
 
         vm.prank(templateAdmin);


### PR DESCRIPTION
* Replace ERC721A with Solady ERC721
* Remove ERC721A dependency from repo
* Replace `mint(to, amount)` with `mint(to, tokenId)` - We are aware this change may cause confusion as the selector is the same
* Add `mintSequential(to, amount)` to cover old functionality
* Add `totalSupply()` that existed in ERC721A but not solady implementation

The following functions are also lost with the library change:
* `explicitOwnershipOf(uint256)`
* `explicitOwnershipsOf(uint256[])`
* `tokensOfOwner(address)`
* `tokensOfOwnerIn(address,uint256,uint256)`
These are unused in our stack. 