### PR TITLE
remove set pack content from initialize()

### DIFF
--- a/src/tokens/ERC1155/presets/pack/ERC1155Pack.sol
+++ b/src/tokens/ERC1155/presets/pack/ERC1155Pack.sol
@@ -21,7 +21,7 @@ contract ERC1155Pack is ERC1155Items, IERC1155Pack {
 
     constructor() ERC1155Items() { }
 
-    /// @inheritdoc IERC1155Pack
+    /// @inheritdoc ERC1155Items
     function initialize(
         address owner,
         string memory tokenName,
@@ -30,14 +30,9 @@ contract ERC1155Pack is ERC1155Items, IERC1155Pack {
         address royaltyReceiver,
         uint96 royaltyFeeNumerator,
         address implicitModeValidator,
-        bytes32 implicitModeProjectId,
-        bytes32 _merkleRoot,
-        uint256 _supply
-    ) public virtual {
+        bytes32 implicitModeProjectId
+    ) public virtual override {
         _grantRole(PACK_ADMIN_ROLE, owner);
-        merkleRoot[0] = _merkleRoot;
-        supply[0] = _supply;
-        remainingSupply[0] = _supply;
         super.initialize(
             owner,
             tokenName,
@@ -71,7 +66,7 @@ contract ERC1155Pack is ERC1155Items, IERC1155Pack {
         uint256 revealAfterBlock = block.number + 1;
         _commitments[packId][msg.sender] = revealAfterBlock;
 
-        emit Commit(msg.sender, revealAfterBlock, packId);
+        emit Commit(msg.sender, packId);
     }
 
     /// @inheritdoc IERC1155Pack

--- a/src/tokens/ERC1155/presets/pack/ERC1155PackFactory.sol
+++ b/src/tokens/ERC1155/presets/pack/ERC1155PackFactory.sol
@@ -31,9 +31,7 @@ contract ERC1155PackFactory is IERC1155PackFactory, SequenceProxyFactory {
         address royaltyReceiver,
         uint96 royaltyFeeNumerator,
         address implicitModeValidator,
-        bytes32 implicitModeProjectId,
-        bytes32 merkleRoot,
-        uint256 supply
+        bytes32 implicitModeProjectId
     ) external override returns (address proxyAddr) {
         bytes32 salt = keccak256(
             abi.encode(
@@ -56,9 +54,7 @@ contract ERC1155PackFactory is IERC1155PackFactory, SequenceProxyFactory {
             royaltyReceiver,
             royaltyFeeNumerator,
             implicitModeValidator,
-            implicitModeProjectId,
-            merkleRoot,
-            supply
+            implicitModeProjectId
         );
         emit ERC1155PackDeployed(proxyAddr);
         return proxyAddr;

--- a/src/tokens/ERC1155/presets/pack/IERC1155Pack.sol
+++ b/src/tokens/ERC1155/presets/pack/IERC1155Pack.sol
@@ -41,37 +41,10 @@ interface IERC1155Pack {
     error AllPacksOpened();
 
     /// @notice Emitted when a user make a commitment
-    event Commit(address indexed user, uint256 blockNumber, uint256 packId);
+    event Commit(address indexed user, uint256 packId);
 
     /// @notice Emitted when a reveal is successful
     event Reveal(address user, uint256 packId);
-
-    /**
-     * Initialize the contract.
-     * @param owner Owner address
-     * @param tokenName Token name
-     * @param tokenBaseURI Base URI for token metadata
-     * @param tokenContractURI Contract URI for token metadata
-     * @param royaltyReceiver Address of who should be sent the royalty payment
-     * @param royaltyFeeNumerator The royalty fee numerator in basis points (e.g. 15% would be 1500)
-     * @param implicitModeValidator The implicit mode validator address
-     * @param implicitModeProjectId The implicit mode project id
-     * @param _merkleRoot merkle root built from all possible pack contents.
-     * @param _supply total amount of packs.
-     * @dev This should be called immediately after deployment.
-     */
-    function initialize(
-        address owner,
-        string memory tokenName,
-        string memory tokenBaseURI,
-        string memory tokenContractURI,
-        address royaltyReceiver,
-        uint96 royaltyFeeNumerator,
-        address implicitModeValidator,
-        bytes32 implicitModeProjectId,
-        bytes32 _merkleRoot,
-        uint256 _supply
-    ) external;
 
     /**
      * Set all possible pack contents.

--- a/src/tokens/ERC1155/presets/pack/IERC1155PackFactory.sol
+++ b/src/tokens/ERC1155/presets/pack/IERC1155PackFactory.sol
@@ -14,8 +14,6 @@ interface IERC1155PackFactoryFunctions {
      * @param royaltyFeeNumerator The royalty fee numerator in basis points (e.g. 15% would be 1500)
      * @param implicitModeValidator The implicit mode validator address
      * @param implicitModeProjectId The implicit mode project id
-     * @param merkleRoot merkle root built from all possible pack contents.
-     * @param supply total amount of packs.
      * @return proxyAddr The address of the ERC-1155 Pack Proxy
      */
     function deploy(
@@ -27,9 +25,7 @@ interface IERC1155PackFactoryFunctions {
         address royaltyReceiver,
         uint96 royaltyFeeNumerator,
         address implicitModeValidator,
-        bytes32 implicitModeProjectId,
-        bytes32 merkleRoot,
-        uint256 supply
+        bytes32 implicitModeProjectId
     ) external returns (address proxyAddr);
 
     /**

--- a/test/tokens/ERC1155/presets/ERC1155Pack.t.sol
+++ b/test/tokens/ERC1155/presets/ERC1155Pack.t.sol
@@ -71,9 +71,12 @@ contract ERC1155PackTest is TestHelper, IERC1155ItemsSignals {
 
         pack = ERC1155Pack(
             factory.deploy(
-                proxyOwner, owner, "name", "baseURI", "contractURI", address(this), 0, address(0), bytes32(0), root, 4
+                proxyOwner, owner, "name", "baseURI", "contractURI", address(this), 0, address(0), bytes32(0)
             )
         );
+
+        vm.prank(owner);
+        pack.setPacksContent(root, 4, 0);
 
         reentryAttacker = new PackReentryMock(address(pack));
 
@@ -83,11 +86,8 @@ contract ERC1155PackTest is TestHelper, IERC1155ItemsSignals {
     }
 
     function testReinitializeFails() public {
-        _preparePacksContent();
-        (bytes32 root,) = TestHelper.getMerklePartsPacks(packsContent, 0);
-
         vm.expectRevert(InvalidInitialization.selector);
-        pack.initialize(owner, "name", "baseURI", "contractURI", address(this), 0, address(0), bytes32(0), root, 3);
+        pack.initialize(owner, "name", "baseURI", "contractURI", address(this), 0, address(0), bytes32(0));
     }
 
     function testSupportsInterface() public view {
@@ -189,9 +189,7 @@ contract ERC1155PackTest is TestHelper, IERC1155ItemsSignals {
             params.royaltyReceiver,
             params.royaltyFeeNumerator,
             params.implicitModeValidator,
-            params.implicitModeProjectId,
-            params.merkleRoot,
-            params.supply
+            params.implicitModeProjectId
         );
         address predictedAddr = factory.determineAddress(
             params.proxyOwner,
@@ -324,9 +322,10 @@ contract ERC1155PackTest is TestHelper, IERC1155ItemsSignals {
         (bytes32 root,) = TestHelper.getMerklePartsPacks(packsContent, 0);
 
         ERC1155PackHack packHack = new ERC1155PackHack();
-        packHack.initialize(
-            owner, "name", "baseURI", "contractURI", address(this), 0, address(0), bytes32(0), root, size
-        );
+        packHack.initialize(owner, "name", "baseURI", "contractURI", address(this), 0, address(0), bytes32(0));
+
+        vm.prank(owner);
+        packHack.setPacksContent(root, size, 0);
 
         pack = packHack;
 


### PR DESCRIPTION
With  the new update is better to set the pack content after contract initialization since user may want to set the content for a specific tokenId