### PR TITLE
Revert to evm version Paris to support chains that don't have PUSH0

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,6 +4,7 @@ out = 'out'
 libs = ['lib']
 solc = "0.8.27"
 solc-version = "0.8.27"
+evm_version = "paris"
 via_ir = true
 use_literal_content = true
 

--- a/src/tokens/ERC1155/presets/pack/ERC1155Pack.sol
+++ b/src/tokens/ERC1155/presets/pack/ERC1155Pack.sol
@@ -103,10 +103,11 @@ contract ERC1155Pack is ERC1155Items, IERC1155Pack {
 
     /// @inheritdoc IERC1155Pack
     function refundPack(address user, uint256 packId) external {
-        if (_commitments[packId][user] == 0) {
+        uint256 commitment = _commitments[packId][user];
+        if (commitment == 0) {
             revert NoCommit();
         }
-        if (uint256(blockhash(_commitments[packId][user])) != 0 || block.number <= _commitments[packId][user]) {
+        if (uint256(blockhash(commitment)) != 0 || block.number <= commitment) {
             revert PendingReveal();
         }
         delete _commitments[packId][user];
@@ -124,13 +125,13 @@ contract ERC1155Pack is ERC1155Items, IERC1155Pack {
             revert AllPacksOpened();
         }
 
-        bytes32 blockHash = blockhash(_commitments[packId][user]);
+        uint256 commitment = _commitments[packId][user];
+        if (commitment == 0) {
+            revert NoCommit();
+        }
+        bytes32 blockHash = blockhash(commitment);
         if (uint256(blockHash) == 0) {
             revert InvalidCommit();
-        }
-
-        if (_commitments[packId][user] == 0) {
-            revert NoCommit();
         }
 
         randomIdx = uint256(keccak256(abi.encode(blockHash, user))) % remainingSupply[packId];

--- a/src/tokens/ERC1155/presets/pack/ERC1155Pack.sol
+++ b/src/tokens/ERC1155/presets/pack/ERC1155Pack.sol
@@ -6,7 +6,7 @@ import { ERC1155Items } from "../items/ERC1155Items.sol";
 import { IERC1155ItemsFunctions } from "../items/IERC1155Items.sol";
 import { IERC1155Pack } from "./IERC1155Pack.sol";
 
-import { MerkleProof } from "openzeppelin-contracts/contracts/utils/cryptography/MerkleProof.sol";
+import { MerkleProofLib } from "solady/utils/MerkleProofLib.sol";
 
 contract ERC1155Pack is ERC1155Items, IERC1155Pack {
 
@@ -79,7 +79,7 @@ contract ERC1155Pack is ERC1155Items, IERC1155Pack {
         (uint256 randomIndex, uint256 revealIdx) = _getRevealIdx(user, packId);
 
         bytes32 leaf = keccak256(abi.encode(revealIdx, packContent));
-        if (!MerkleProof.verify(proof, merkleRoot[packId], leaf)) {
+        if (!MerkleProofLib.verify(proof, merkleRoot[packId], leaf)) {
             revert InvalidProof();
         }
 

--- a/src/tokens/ERC1155/presets/pack/ERC1155Pack.sol
+++ b/src/tokens/ERC1155/presets/pack/ERC1155Pack.sol
@@ -59,9 +59,6 @@ contract ERC1155Pack is ERC1155Items, IERC1155Pack {
         if (_commitments[packId][msg.sender] != 0) {
             revert PendingReveal();
         }
-        if (balanceOf(msg.sender, packId) == 0) {
-            revert NoBalance();
-        }
         _burn(msg.sender, packId, 1);
         uint256 revealAfterBlock = block.number + 1;
         _commitments[packId][msg.sender] = revealAfterBlock;

--- a/src/tokens/ERC1155/presets/pack/IERC1155Pack.sol
+++ b/src/tokens/ERC1155/presets/pack/IERC1155Pack.sol
@@ -26,11 +26,6 @@ interface IERC1155Pack {
     error NoCommit();
 
     /**
-     * No balance.
-     */
-    error NoBalance();
-
-    /**
      * Invalid proof.
      */
     error InvalidProof();

--- a/test/tokens/ERC1155/presets/ERC1155Pack.t.sol
+++ b/test/tokens/ERC1155/presets/ERC1155Pack.t.sol
@@ -18,6 +18,8 @@ import { IERC165 } from "openzeppelin-contracts/contracts/utils/introspection/IE
 
 import { ISignalsImplicitMode } from "signals-implicit-mode/src/helper/SignalsImplicitMode.sol";
 
+import { ERC1155 } from "solady/tokens/ERC1155.sol";
+
 contract ERC1155PackHack is ERC1155Pack {
 
     function setAllExceptOneClaimed(
@@ -218,7 +220,7 @@ contract ERC1155PackTest is TestHelper, IERC1155ItemsSignals {
     ) public {
         assumeSafeAddress(user);
         vm.prank(user);
-        vm.expectRevert(IERC1155Pack.NoBalance.selector);
+        vm.expectRevert(ERC1155.InsufficientBalance.selector);
         pack.commit(0);
     }
 


### PR DESCRIPTION
Also optimise ERC1155Pack to be within the runtime bytecode limit. 

```╭-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------╮
| Contract                                                                    | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
+===============================================================================================================================================================+
| Address                                                                     | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| AddressUpgradeable                                                          | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| Base64                                                                      | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| BeaconProxy                                                                 | 719              | 763               | 23,857             | 48,389              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| Clawback                                                                    | 23,628           | 25,624            | 948                | 23,528              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ClawbackMetadata                                                            | 12,805           | 12,849            | 11,771             | 36,303              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| Clones                                                                      | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| Create2                                                                     | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| Duration                                                                    | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ECDSA                                                                       | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC1155Items                                                                | 19,334           | 19,399            | 5,242              | 29,753              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC1155ItemsFactory                                                         | 10,010           | 33,050            | 14,566             | 16,102              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC1155Mock                                                                 | 17,758           | 20,605            | 6,818              | 28,547              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC1155Pack                                                                 | 24,425           | 24,506            | 151                | 24,646              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC1155PackFactory                                                          | 10,010           | 38,157            | 14,566             | 10,995              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC1155PackHack                                                             | 24,606           | 24,695            | -30                | 24,457              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC1155PermissiveMinter                                                     | 9,065            | 10,896            | 15,511             | 38,256              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC1155Sale                                                                 | 18,192           | 18,236            | 6,384              | 30,916              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC1155SaleFactory                                                          | 9,684            | 31,561            | 14,892             | 17,591              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC1155Soulbound                                                            | 20,167           | 20,264            | 4,409              | 28,888              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC1155SoulboundFactory                                                     | 10,010           | 33,915            | 14,566             | 15,237              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC1271Mock                                                                 | 1,139            | 1,183             | 23,437             | 47,969              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC1967Proxy                                                                | 277              | 321               | 24,299             | 48,831              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC20                                                                       | 4,341            | 5,434             | 20,235             | 43,718              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC20Items                                                                  | 14,266           | 15,328            | 10,310             | 33,824              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC20ItemsFactory                                                           | 9,890            | 28,859            | 14,686             | 20,293              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC20Mock                                                                   | 14,005           | 17,077            | 10,571             | 32,075              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC721Items                                                                 | 16,731           | 16,796            | 7,845              | 32,356              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC721ItemsFactory                                                          | 10,082           | 30,519            | 14,494             | 18,633              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC721Mock                                                                  | 16,042           | 18,909            | 8,534              | 30,243              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC721PermissiveMinter                                                      | 8,061            | 9,892             | 16,515             | 39,260              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC721Sale                                                                  | 14,998           | 15,042            | 9,578              | 34,110              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC721SaleFactory                                                           | 9,532            | 28,215            | 15,044             | 20,937              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC721Soulbound                                                             | 17,355           | 17,452            | 7,221              | 31,700              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC721SoulboundFactory                                                      | 10,082           | 31,175            | 14,494             | 17,977              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| EnumerableSet                                                               | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| LibAttestation                                                              | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| LibBytes (lib/signals-implicit-mode/lib/sequence-v3/src/utils/LibBytes.sol) | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| LibBytes (lib/solady/src/utils/LibBytes.sol)                                | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| LibString                                                                   | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| Math                                                                        | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| Merkle                                                                      | 4,900            | 4,944             | 19,676             | 44,208              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| MerkleProof                                                                 | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| MerkleProofLib                                                              | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| MockImplementationV1                                                        | 262              | 306               | 24,314             | 48,846              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| MockImplementationV2                                                        | 262              | 306               | 24,314             | 48,846              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| MockImplementationV3                                                        | 262              | 306               | 24,314             | 48,846              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| MockSignalsImplicitMode                                                     | 8,117            | 8,161             | 16,459             | 40,991              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| PackReentryMock                                                             | 8,827            | 9,247             | 15,749             | 39,905              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| Payload                                                                     | 870              | 918               | 23,706             | 48,234              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| PaymentCombiner                                                             | 6,419            | 15,546            | 18,157             | 33,606              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| PaymentSplitter                                                             | 8,810            | 8,854             | 15,766             | 40,298              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| PaymentSplitterUpgradeable                                                  | 5,686            | 5,730             | 18,890             | 43,422              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| Payments                                                                    | 8,187            | 8,616             | 16,389             | 40,536              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| PaymentsFactory                                                             | 9,413            | 21,670            | 15,163             | 27,482              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| PublicSequenceProxyFactory                                                  | 9,125            | 12,694            | 15,451             | 36,458              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| SafeERC20                                                                   | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| SafeERC20Upgradeable                                                        | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| SafeTransferLib                                                             | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| SignatureValidator                                                          | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| SignedMath                                                                  | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| StorageSlot (lib/openzeppelin-contracts/contracts/utils/StorageSlot.sol)    | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| StorageSlot (src/utils/StorageSlot.sol)                                     | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| Strings                                                                     | 63               | 108               | 24,513             | 49,044              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| TransparentUpgradeableBeaconProxy                                           | 5,214            | 5,258             | 19,362             | 43,894              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| TransparentUpgradeableProxy                                                 | 3,504            | 3,548             | 21,072             | 45,604              |
|-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| UpgradeableBeacon                                                           | 1,826            | 2,722             | 22,750             | 46,430              |
╰-----------------------------------------------------------------------------+------------------+-------------------+--------------------+---------------------╯```