### PR TITLE
feat: adding pack opening start time config

### DIFF
--- a/src/tokens/ERC1155/presets/pack/IERC1155Pack.sol
+++ b/src/tokens/ERC1155/presets/pack/IERC1155Pack.sol
@@ -35,11 +35,19 @@ interface IERC1155Pack {
      */
     error AllPacksOpened();
 
+    /**
+     * Pack is not yet available for opening.
+     */
+    error PackNotYetAvailable();
+
     /// @notice Emitted when a user make a commitment
     event Commit(address indexed user, uint256 packId);
 
     /// @notice Emitted when a reveal is successful
     event Reveal(address user, uint256 packId);
+
+    /// @notice Emitted when a pack opening start time is set
+    event PackOpeningStartTimeSet(uint256 indexed packId, uint256 startTime);
 
     /**
      * Set all possible pack contents.
@@ -87,5 +95,12 @@ interface IERC1155Pack {
      * @notice this function mints a pack for the user when his commit is expired.
      */
     function refundPack(address user, uint256 packId) external;
+
+    /**
+     * Set the start time for when a pack can be opened.
+     * @param packId tokenId of pack.
+     * @param startTime timestamp after which the pack can be opened (0 means no restriction).
+     */
+    function setPackOpeningStartTime(uint256 packId, uint256 startTime) external;
 
 }


### PR DESCRIPTION
**What does this PR do**
- Introduced a new ERC1155Pack config variable: `packOpeningStartTime`
- `commit()` & `reveal()` are checked against this value (if set) to determine if the processing is allowed to continue.
- Added tests for functionality and maintaining backward compatibility if not set.

_Note_: Technically we shouldn't get into a state where the commit succeeds but the reveal is blocked by the `packOpeningStartTime`, but added the check for completeness. 
Potential approaches if we don't like that:
- Remove the check during `reveal()`
- Add a separate config option to independently control commit/reveals

Open to suggestions!