### PR TITLE
chore: update company name references

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-   Copyright (c) 2023-present Sequence Platforms ULC Inc.
+   Copyright (c) 2023-present Sequence Platforms ULC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-   Copyright (c) 2023-present Horizon Blockchain Games Inc.
+   Copyright (c) 2023-present Sequence Platforms ULC Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "source": "src/index.ts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "author": "Horizon Blockchain Games",
+  "author": "Sequence Platforms ULC",
   "license": "Apache-2.0",
   "scripts": {
     "build": "forge build --force",


### PR DESCRIPTION
Automated cleanup of legacy company name references:

- "Horizon Blockchain Games" → "Sequence Platforms ULC"
- "Sequence Platforms Inc." → "Sequence Platforms ULC"
- "Horizon" → "Sequence"

Scope: README / LICENSE / package.json files (excluding vendor/).